### PR TITLE
BAU - Fix `tag` spelling error

### DIFF
--- a/workspace.tf
+++ b/workspace.tf
@@ -11,7 +11,7 @@ resource "tfe_workspace" "ws" {
   structured_run_output_enabled = var.structured_run_output_enabled
   ssh_key_id                    = var.ssh_key_id
   tag_names                     = var.workspace_tags
-  tag                           = var.workspace_map_tags
+  tags                          = var.workspace_map_tags
   terraform_version             = var.terraform_version
   trigger_prefixes              = var.trigger_prefixes
   trigger_patterns              = var.trigger_patterns


### PR DESCRIPTION
Description:
- Should be `tags` not `tag` - https://github.com/alexbasista/terraform-tfe-workspacer/pull/30